### PR TITLE
Boolean function sum-of-products expansion

### DIFF
--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -31,18 +31,18 @@
         <input>
             P = [1, 2, 3, 4, 5, 6]
 
-            poset_divisors_6 = Poset((P, attrcall("divides")))
+            divisibility_poset = Poset((P, attrcall("divides")))
 
-            show(poset_divisors_6)
+            show(divisibility_poset)
         </input>
     </sage>
     <sage>
         <input>
-            is_boolean_algebra(poset_divisors_6)
+            is_boolean_algebra(divisibility_poset)
         </input>
     </sage>
     <p>
-        When we pass <m>P</m> to the <c>is_boolean_algebra()</c> function, <c>LatticePoset()</c> raises an error because <m>P</m> is not a lattice. The <c>ValueError</c> provides more information about the absence of a top element. Therefore, <c>poset_divisors_6</c> is not a Boolean algebra.
+        When we pass <m>P</m> to the <c>is_boolean_algebra()</c> function, <c>LatticePoset()</c> raises an error because <m>P</m> is not a lattice. The <c>ValueError</c> provides more information about the absence of a top element. Therefore, <c>divisibility_poset</c> is not a Boolean algebra.
     </p>
     <sage>
         <input>

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -28,7 +28,7 @@
     <sage>
         <input>
             P = [1, 2, 3, 4, 5, 6]
-            
+
             poset_divisors_6 = Poset((P, attrcall("divides")))
 
             show(poset_divisors_6)
@@ -37,6 +37,17 @@
     <sage>
         <input>
             is_boolean_algebra(poset_divisors_6)
+        </input>
+    </sage>
+    <sage>
+        <input>
+            S = {'a', 'b', 'c'}
+
+            power_set = Subsets(S)
+
+            P = Poset((power_set, lambda x, y: x.issubset(y)))
+
+            P.plot(vertex_size=1000,vertex_shape="")
         </input>
     </sage>
 

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -50,6 +50,11 @@
             P.plot(vertex_size=1000,vertex_shape="")
         </input>
     </sage>
+    <sage>
+        <input>
+            is_boolean_algebra(P)
+        </input>
+    </sage>
 
     <aside>
         <p>

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -22,31 +22,24 @@
                 return True, "The poset is a Boolean algebra."
         </input>
     </sage>
-    
-    <sage>
-        <input>
-            p = Posets.DivisorLattice(20)
-            p.show()
-        </input>
-    </sage>
     <p>
-        The following Sage cell checks whether the divisor lattice is distributive. A distributive lattice is one where the operations of join and meet distribute over each other.
+        Let's check if the following poset is a Boolean algebra.
     </p>
     <sage>
         <input>
-            p = Posets.DivisorLattice(20)
-            p.is_distributive()
+            P = [1, 2, 3, 4, 5, 6]
+            
+            poset_divisors_6 = Poset((P, attrcall("divides")))
+
+            show(poset_divisors_6)
         </input>
     </sage>
-    <p>
-        Another important property in Boolean algebra is the complemented lattice. A complemented lattice is one where every element has a complement in the lattice.
-    </p>
     <sage>
         <input>
-            p = Posets.DivisorLattice(20)
-            p.is_complemented()
+            is_boolean_algebra(poset_divisors_6)
         </input>
     </sage>
+
     <aside>
         <p>
             Software engineers use Boolean algebra to simplify conditions, refactor code, and optimize logic. These skills are crucial for identifying bottlenecks and improving efficiency in real-time systems and performance-critical applications.

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -5,7 +5,7 @@
     </p>
     <aside>
         <p>
-            In computer software, Boolean algebra is used to construct and simplify expressions in programming languages that support logical decision-making processes. This simplification is critical in developing efficient algorithms and software that perform millions of calculations and logical operations per second.
+            In digital electronics, the principles of Boolean algebra guide the design of circuits such as multiplexers, demultiplexers, encoders, and decoders, essential components in telecommunications and signal processing.
         </p>
     </aside>
     <sage>
@@ -29,11 +29,6 @@
             # Returns True if the lattice is distributive, along with a certificate if applicable.
         </output>
     </sage>
-    <aside>
-        <p>
-            In digital electronics, the principles of Boolean algebra guide the design of circuits such as multiplexers, demultiplexers, encoders, and decoders, essential components in telecommunications and signal processing.
-        </p>
-    </aside>
     <p>
         Another important property in Boolean algebra is the complemented lattice. A complemented lattice is one where every element has a complement in the lattice.
     </p>
@@ -46,4 +41,9 @@
             # Returns True if the lattice is complemented, along with a certificate if applicable.
         </output>
     </sage>
+    <aside>
+        <p>
+            Software engineers use Boolean algebra to simplify conditions, refactor code, and optimize logic. These skills are crucial for identifying bottlenecks and improving efficiency in real-time systems and performance-critical applications.
+        </p>
+    </aside>
 </section>

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -11,13 +11,15 @@
     <sage>
         <input>
             def is_boolean_algebra(P):
-                if not P.is_lattice():
-                    return False, "The poset is not a lattice."
-                if not P.is_bounded():
+                try:
+                    L = LatticePoset(P)
+                except ValueError as e:
+                    return False, str(e)
+                if not L.is_bounded():
                     return False, "The lattice is not bounded."
-                if not P.is_distributive():
+                if not L.is_distributive():
                     return False, "The lattice is not distributive."
-                if not P.is_complemented():
+                if not L.is_complemented():
                     return False, "The lattice is not complemented."
                 return True, "The poset is a Boolean algebra."
         </input>
@@ -39,6 +41,10 @@
             is_boolean_algebra(poset_divisors_6)
         </input>
     </sage>
+    <p>
+        Since we get the message <c>(False, 'not a join-semilattice: no top element')
+        </c>, we know that the <c>poset_divisors_6</c> is not a not a Boolean algebra because it is not bounded. Let's try another example.
+    </p>
     <sage>
         <input>
             S = {'a', 'b', 'c'}

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -6,7 +6,7 @@
         </p>
     </aside>
     <p>
-        A  Boolean algebra is a bounded lattice that is both complemented and distributive. Let's define a function, <c>is_boolean_algebra()</c> to determine whether a given poset is a Boolean algebra. The function accepts a finite partially ordered set as input and returns a tuple containing a boolean value and a message explaining the result. Run the following cell to define the function and call it in other cells.
+        A  Boolean algebra is a bounded lattice that is both complemented and distributive. Let's define the <c>is_boolean_algebra()</c> function to determine whether a given poset is a Boolean algebra. The function accepts a finite partially ordered set as input and returns a tuple containing a boolean value and a message explaining the result. Run the following cell to define the function and call it in other cells.
     </p>
     <sage>
         <input>
@@ -42,7 +42,7 @@
         </input>
     </sage>
     <p>
-        Since we get the message <c>(False, 'not a join-semilattice: no top element')</c>, we know that the <c>poset_divisors_6</c> is not a not a Boolean algebra because it is not bounded. Let's try another example.
+        When we pass <m>P</m> to the <c>is_boolean_algebra()</c> function, <c>LatticePoset()</c> raises an error because <m>P</m> is not a lattice. The <c>ValueError</c> provides more information about the absence of a top element. Therefore, <c>poset_divisors_6</c> is not a Boolean algebra.
     </p>
     <sage>
         <input>

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -1,13 +1,28 @@
 <section xml:id="sec-boolean-algebra" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Boolean Algebra</title><idx><h>Boolean Algebra</h></idx>
-    <p>
-        A  Boolean algebra is a bounded lattice that is both complemented and distributive.
-    </p>
     <aside>
         <p>
             In digital electronics, the principles of Boolean algebra guide the design of circuits such as multiplexers, demultiplexers, encoders, and decoders, essential components in telecommunications and signal processing.
         </p>
     </aside>
+    <p>
+        A  Boolean algebra is a bounded lattice that is both complemented and distributive. Let's define a function, <c>is_boolean_algebra()</c> to determine whether a given poset is a Boolean algebra. The function accepts a finite partially ordered set as input and returns a tuple containing a boolean value and a message explaining the result. Run the following cell to define the function and call it in other cells.
+    </p>
+    <sage>
+        <input>
+            def is_boolean_algebra(P):
+                if not P.is_lattice():
+                    return False, "The poset is not a lattice."
+                if not P.is_bounded():
+                    return False, "The lattice is not bounded."
+                if not P.is_distributive():
+                    return False, "The lattice is not distributive."
+                if not P.is_complemented():
+                    return False, "The lattice is not complemented."
+                return True, "The poset is a Boolean algebra."
+        </input>
+    </sage>
+    
     <sage>
         <input>
             p = Posets.DivisorLattice(20)

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -80,6 +80,16 @@
             is_boolean_algebra(dl20)
         </input>
     </sage>
+    <p>
+        Here is a classic example in the field of computer science:
+    </p>
+    <sage>
+        <input>
+            B = posets.BooleanLattice(1)
+            show(B)
+            is_boolean_algebra(B)
+        </input>
+    </sage>
     <aside>
         <p>
             Software engineers use Boolean algebra to simplify conditions, refactor code, and optimize logic. These skills are crucial for identifying bottlenecks and improving efficiency in real-time systems and performance-critical applications.

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -13,9 +13,6 @@
             p = Posets.DivisorLattice(20)
             p.show()
         </input>
-        <output>
-            # This will display the lattice structure for divisors of the number 20.
-        </output>
     </sage>
     <p>
         The following Sage cell checks whether the divisor lattice is distributive. A distributive lattice is one where the operations of join and meet distribute over each other.
@@ -25,9 +22,6 @@
             p = Posets.DivisorLattice(20)
             p.is_distributive()
         </input>
-        <output>
-            # Returns True if the lattice is distributive, along with a certificate if applicable.
-        </output>
     </sage>
     <p>
         Another important property in Boolean algebra is the complemented lattice. A complemented lattice is one where every element has a complement in the lattice.
@@ -37,9 +31,6 @@
             p = Posets.DivisorLattice(20)
             p.is_complemented()
         </input>
-        <output>
-            # Returns True if the lattice is complemented, along with a certificate if applicable.
-        </output>
     </sage>
     <aside>
         <p>

--- a/source/boolean-algebra/sec-boolean-algebra.ptx
+++ b/source/boolean-algebra/sec-boolean-algebra.ptx
@@ -42,8 +42,7 @@
         </input>
     </sage>
     <p>
-        Since we get the message <c>(False, 'not a join-semilattice: no top element')
-        </c>, we know that the <c>poset_divisors_6</c> is not a not a Boolean algebra because it is not bounded. Let's try another example.
+        Since we get the message <c>(False, 'not a join-semilattice: no top element')</c>, we know that the <c>poset_divisors_6</c> is not a not a Boolean algebra because it is not bounded. Let's try another example.
     </p>
     <sage>
         <input>
@@ -61,7 +60,26 @@
             is_boolean_algebra(P)
         </input>
     </sage>
-
+    <p>
+        Let's examine the divisor lattice of 30:
+    </p>
+    <sage>
+        <input>
+            dl30 = Posets.DivisorLattice(30)
+            show(dl30)
+            is_boolean_algebra(dl30)
+        </input>
+    </sage>
+    <p>
+        Now for the divisor lattice of 20:
+    </p>
+    <sage>
+        <input>
+            dl20 = Posets.DivisorLattice(20)
+            show(dl20)
+            is_boolean_algebra(dl20)
+        </input>
+    </sage>
     <aside>
         <p>
             Software engineers use Boolean algebra to simplify conditions, refactor code, and optimize logic. These skills are crucial for identifying bottlenecks and improving efficiency in real-time systems and performance-critical applications.

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -1,10 +1,7 @@
 <section xml:id="sec-boolean-functions" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Boolean functions</title><idx><h>Boolean functions</h></idx>
     <p>
-        A  Boolean function is a function that takes only values 0 or 1 and whose domain is the Cartesian product <m>{\{0, 1\}^n}</m>.
-    </p>
-    <p>
-        In SageMath, Boolean functions can be manipulated through various built-in functions designed for handling Boolean variables and expressions.
+        A  <term>Boolean function</term> is a function that takes only values 0 or 1 and whose domain is the Cartesian product <m>{\{0, 1\}^n}</m>.
     </p>
     <aside>
         <title>Notes</title>
@@ -21,25 +18,56 @@
         </input>
     </sage>
     <p>
-        Now let's examine the truth table of the Boolean function <m>h(x, y) = x + \bar{y}</m>.
+        Every Boolean function can be written as a sum-of-products expansion by applying the Boolean identities. Let's find the sum-of-products expansion of the Boolean function <me>h(x, y) = x + \bar{y}</me>. Right now we have a sum of two terms, but no products. We can apply the identity law to introduce the product terms. Now we have the equivalent expression <me>h(x, y) = x \cdot 1 + 1 \cdot \bar{y}</me>.
+    </p>
+    <p>
+        Warning: Do not attempt to apply the identity law or null law within the <c>formula</c> function. The <c>formula</c> function only supports variables and the following operators:
+        <ul>
+            <li>
+                <p>
+                    <c>&amp;</c> <m>and</m>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <c>|</c> <m>or</m>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <c>~</c> <m>not</m>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <c>^</c> <m>xor</m>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <c>-&gt;</c> <m>if\; then</m>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <c>&lt;-&gt;</c> <m>if\; and\; only\; if</m>
+                </p>
+            </li>
+        </ul>
     </p>
     <sage>
         <input>
             h = formula("x | ~y")
-            h.truthtable()
         </input>
     </sage>
-    <p>
-        Every Boolean function can be written as a sum-of-products expansion by applying the Boolean identities. Let's find the sum-of-products expansion of the Boolean function <m>h(x, y) = x + \bar{y}</m>.
-    </p>
     <sage>
         <input>
-            # Applying the identity law
-            # Warning: Do not use 
-            # formula("x &amp; True | True &amp; ~y")
-            # h == formula("x &amp; True | True &amp; ~y")
-            # True and False are not boolean supported with formula
-            # Instead we can assume the &amp; True
+            # Warning: Do not directly apply the identity law
+            # within the formula function
+            # This will raise an error because
+            # `1` is interpreted as a variable
+            # variables cannot start with a number
+            formula("x &amp; 1 | True 1 ~y")
         </input>
     </sage>
 
@@ -58,7 +86,7 @@
         </input>
     </sage>
     <p>
-        Here is the sum-of-products expansion of the Boolean function <m>h(x, y) = x + \bar{y}</m>. After applying the identity, complement, and distributive laws, we get <m>h(x, y) = x \cdot y + x \cdot \bar{y} + x \cdot \bar{y} + \bar{x} \cdot \bar{y}</m>.
+        Here is the sum-of-products expansion of the Boolean function <me>h(x, y) = x + \bar{y}</me>. After applying the identity, complement, and distributive laws, we get <me>h(x, y) = x \cdot y + x \cdot \bar{y} + x \cdot \bar{y} + \bar{x} \cdot \bar{y}</me>.
     </p>
     <sage>
         <input>
@@ -67,9 +95,6 @@
             h_idempotent == h
         </input>
     </sage>
-    <p>
-        We can also confirm the truth table of the <m>h(x, y) = x + \bar{y}</m> and <m>h(x, y) = x \cdot y + x \cdot \bar{y} + x \cdot \bar{y} + \bar{x} \cdot \bar{y}</m> are the same.
-    </p>
     <sage>
         <input>
             h_idempotent.truthtable()
@@ -81,7 +106,18 @@
             h_idempotent.truthtable() == h.truthtable()
         </input>
     </sage>
-    
+    <p>
+        Now let's examine the truth table of the Boolean function <m>h(x, y) = x + \bar{y}</m>.
+    </p>
+    <sage>
+        <input>
+            h = formula("x | ~y")
+            h.truthtable()
+        </input>
+    </sage>
+    <p>
+        Using boolean identities is one way of finding the sum-of-products expansion of a Boolean function. Let's find a more programmatic way to find the sum-of-products expansion of the Boolean function.
+    </p>
     <idx><h>polynomial</h></idx>
     <sage>
         <input>
@@ -89,8 +125,5 @@
             f = B('x0 + x1 * x2')
             show(f)
         </input>
-        <output>
-            # Outputs the Boolean expression in polynomial form
-        </output>
     </sage>
 </section>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -75,6 +75,12 @@
             h_idempotent.truthtable()
         </input>
     </sage>
+    <sage>
+        <input>
+            # Why is this False?
+            h_idempotent.truthtable() == h.truthtable()
+        </input>
+    </sage>
     
     <idx><h>polynomial</h></idx>
     <sage>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -10,7 +10,7 @@
         </p>
     </aside>
     <p>
-        Before we begin lets import the necessary modules. This will reduce the amount of code we need to type.
+        Before we begin, let's import the necessary modules. The import statement reduces the amount of code we need to write by allowing us to reference the module by its alias and without the module prefix.
     </p>
     <sage>
         <input>
@@ -18,7 +18,7 @@
         </input>
     </sage>
     <p>
-        Every Boolean function can be written as a sum-of-products expansion by applying the Boolean identities. Let's find the sum-of-products expansion of the Boolean function <me>h(x, y) = x + \bar{y}</me>. Right now we have a sum of two terms, but no products. We can apply the identity law to introduce the product terms. Now we have the equivalent expression <me>h(x, y) = x \cdot 1 + 1 \cdot \bar{y}</me>.
+        Boolean identities allow us to write every Boolean function as a sum-of-products expansion. Let's find the sum-of-products expansion of the Boolean function <me>h(x, y) = x + \bar{y}</me>. Currently, we have a sum of two terms, but no products. We can apply the identity law to introduce the product terms. Now, we have the equivalent expression <me>h(x, y) = x \cdot 1 + 1 \cdot \bar{y}</me>.
     </p>
     <p>
         Warning: Do not attempt to apply the identity law or null law within the <c>formula</c> function. The <c>formula</c> function only supports variables and the following operators:
@@ -131,8 +131,8 @@
      </p>
      <sage>
         <input>
-            # Initialize the SOP expression
-            sop_expression = []
+            # Initialize the SOP expansion
+            sop_expansion = []
 
             # Iterate through the truth table
             for row in table_list[1:]:  # Skip the header row ['x', 'y']
@@ -145,7 +145,7 @@
                         else:
                             minterm.append(f'~{var}')  # Include negation if False
                     
-                    sop_expression.append(' &amp; '.join(minterm))  # Combine using AND
+                    sop_expansion.append(' &amp; '.join(minterm))  # Combine using AND
         </input>
      </sage>
      <p>
@@ -153,9 +153,20 @@
      </p>
      <sage>
         <input>
-            sop_result = ' | '.join(f'({m})' for m in sop_expression)
-            print("SOP Expression:", sop_result)
+            sop_result = ' | '.join(f'({m})' for m in sop_expansion)
+            print("SOP expansion:", sop_result)
         </input>
+     </sage>
+     <p>
+        Let's verify that the sum-of-products expansion we found with the truth table is the same as the one we found using boolean identities.
+     </p>
+     <sage>
+        <input>
+            sop_result == h
+        </input>
+        <output>
+            
+        </output>
      </sage>
     <idx><h>polynomial</h></idx>
     <sage>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -123,9 +123,32 @@
             from sage.logic.propcalc import formula
             h = formula("x | ~y")
             truth_table = h.truthtable()
-            truth_table.get_table_list()
+            table_list = truth_table.get_table_list()
         </input>
     </sage>
+    <p>
+        Now, we can iterate over the truth table to find the Sum-of-Products expansion of the Boolean function. For each row where the output is <c>True</c>, we will construct a product term by examining the input values. For each variable, if its value is <c>True</c>, we include the variable in the product; if its value is <c>False</c>, we include its negation in the product.
+     </p>
+     <sage>
+        <input>
+            # Initialize the SOP expression
+            sop_expression = []
+
+            # Iterate through the truth table
+            for row in table_list[1:]:  # Skip the header row ['x', 'y']
+                if row[-1]:  # If the output is True
+                    # Construct the minterm
+                    minterm = []
+                    for var, value in zip(table_list[0], row[:-1]):  # Iterate over variables and their values
+                        if value:
+                            minterm.append(var)  # Include variable as is if True
+                        else:
+                            minterm.append(f'~{var}')  # Include negation if False
+                    
+                    sop_expression.append(' &amp; '.join(minterm))  # Combine using AND
+        </input>
+     </sage>
+
     <idx><h>polynomial</h></idx>
     <sage>
         <input>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -12,6 +12,27 @@
           Boolean algebra is crucial in digital circuit design. For example, simplifying the expression of a digital circuit can minimize the number of gates used, which reduces cost and power consumption. Techniques such as Karnaugh maps and Boolean simplification are common in the industry.
         </p>
     </aside>
+    <p>
+        Before we begin lets import the necessary modules. This will reduce the amount of code we need to type.
+    </p>
+    <sage>
+        <input>
+            from sage.logic.propcalc import formula
+        </input>
+    </sage>
+    <p>
+        Now let's examine the truth table of the Boolean function <m>h(x, y) = x + \bar{y}</m>.
+    </p>
+    <sage>
+        <input>
+            h = formula("x | ~y")
+            h.truthtable()
+        </input>
+    </sage>
+    <p>
+        Every Boolean function can be written as a sum-of-products expansion by applying the Boolean identities. Let's find the sum-of-products expansion of the Boolean function <m>h(x, y) = x + \bar{y}</m>.
+    </p>
+    
     <idx><h>polynomial</h></idx>
     <sage>
         <input>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -58,6 +58,7 @@
     <sage>
         <input>
             h = formula("x | ~y")
+            show(h)
         </input>
     </sage>
     <sage>
@@ -75,6 +76,7 @@
         <input>
             # Applying the complement law
             h_complement = formula("x &amp; (y | ~y) | (x | ~x) &amp;  ~y")
+            show(latex(h_complement) + "==" + latex(h))
             h_complement == h
         </input>
     </sage>
@@ -82,6 +84,7 @@
         <input>
             # Applying the distributive law
             h_distributive = formula("x &amp; y | x &amp; ~y | x &amp; ~y | ~x &amp; ~y")
+            show(latex(h_distributive) + "==" + latex(h))
             h_distributive == h
         </input>
     </sage>
@@ -92,22 +95,12 @@
         <input>
             # Applying the idempotent law
             h_idempotent = formula("x &amp; y | x &amp; ~y | ~x &amp; ~y")
+            show(latex(h_idempotent) + "==" + latex(h))
             h_idempotent == h
         </input>
     </sage>
-    <sage>
-        <input>
-            h_idempotent.truthtable()
-        </input>
-    </sage>
-    <sage>
-        <input>
-            # Why is this False?
-            h_idempotent.truthtable() == h.truthtable()
-        </input>
-    </sage>
     <p>
-        Now let's examine the truth table of the Boolean function <m>h(x, y) = x + \bar{y}</m>.
+        Using boolean identities is one way of finding the sum-of-products expansion of a Boolean function. Let's find a more programmatic way to find the sum-of-products expansion of the Boolean function using the truth table.
     </p>
     <sage>
         <input>
@@ -116,14 +109,14 @@
         </input>
     </sage>
     <p>
-        Using boolean identities is one way of finding the sum-of-products expansion of a Boolean function. Let's find a more programmatic way to find the sum-of-products expansion of the Boolean function. The <c>truthtable()</c> function is not iterable, so we must represent the table as a <c>list</c> with <c>get_table_list()</c>.
+        The <c>truthtable()</c> function is not iterable, so we must represent the table as a <c>list</c> with <c>get_table_list()</c>.
     </p>
     <sage>
         <input>
-            from sage.logic.propcalc import formula
             h = formula("x | ~y")
             truth_table = h.truthtable()
             table_list = truth_table.get_table_list()
+            print(table_list)
         </input>
     </sage>
     <p>
@@ -131,13 +124,9 @@
      </p>
      <sage>
         <input>
-            # Initialize the SOP expansion
             sop_expansion = []
-
-            # Iterate through the truth table
-            for row in table_list[1:]:  # Skip the header row ['x', 'y']
+            for row in table_list[1:]:  # Skip the header row
                 if row[-1]:  # If the output is True
-                    # Construct the minterm
                     minterm = []
                     for var, value in zip(table_list[0], row[:-1]):  # Iterate over variables and their values
                         if value:
@@ -149,7 +138,7 @@
         </input>
      </sage>
      <p>
-        Now, we can combine all minterms:
+        Now, we can combine all minterms to form the sum-of-products expansion:
      </p>
      <sage>
         <input>
@@ -162,18 +151,34 @@
      </p>
      <sage>
         <input>
-            sop_result == h
+            formula(sop_result) == h
         </input>
-        <output>
-            
-        </output>
      </sage>
+     <p>
+        We can also use <c>BooleanPolynomialRing</c> to create Boolean polynomials and perform operations on them. For instance, if <m> B = {0, 1}</m>, we can show a function <m>f: B^3 \to B</m>
+     </p>
     <idx><h>polynomial</h></idx>
     <sage>
         <input>
             B = BooleanPolynomialRing(3, 'x')
             f = B('x0 + x1 * x2')
             show(f)
+        </input>
+    </sage>
+    <p>
+        We can evaluate the function at any 3-uple:
+    </p>
+    <sage>
+        <input>
+            f(1,1,0)
+        </input>
+    </sage>
+    <p>
+        The Sage <c>BooleanPolynomialRing</c> treats <c>+</c> as <m>XOR</m>
+    </p>
+    <sage>
+        <input>
+            f(1,1,1)
         </input>
     </sage>
 </section>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -148,7 +148,15 @@
                     sop_expression.append(' &amp; '.join(minterm))  # Combine using AND
         </input>
      </sage>
-
+     <p>
+        Now, we can combine all minterms:
+     </p>
+     <sage>
+        <input>
+            sop_result = ' | '.join(f'({m})' for m in sop_expression)
+            print("SOP Expression:", sop_result)
+        </input>
+     </sage>
     <idx><h>polynomial</h></idx>
     <sage>
         <input>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -86,7 +86,7 @@
         </input>
     </sage>
     <p>
-        Here is the sum-of-products expansion of the Boolean function <me>h(x, y) = x + \bar{y}</me>. After applying the identity, complement, and distributive laws, we get <me>h(x, y) = x \cdot y + x \cdot \bar{y} + x \cdot \bar{y} + \bar{x} \cdot \bar{y}</me>.
+        Here is the sum-of-products expansion of the Boolean function: <me>h(x, y) = x + \bar{y}</me> After applying the identity, complement, and distributive laws, we get: <me>h(x, y) = x \cdot y + x \cdot \bar{y} + x \cdot \bar{y} + \bar{x} \cdot \bar{y}</me>
     </p>
     <sage>
         <input>
@@ -116,8 +116,16 @@
         </input>
     </sage>
     <p>
-        Using boolean identities is one way of finding the sum-of-products expansion of a Boolean function. Let's find a more programmatic way to find the sum-of-products expansion of the Boolean function.
+        Using boolean identities is one way of finding the sum-of-products expansion of a Boolean function. Let's find a more programmatic way to find the sum-of-products expansion of the Boolean function. The <c>truthtable()</c> function is not iterable, so we must represent the table as a <c>list</c> with <c>get_table_list()</c>.
     </p>
+    <sage>
+        <input>
+            from sage.logic.propcalc import formula
+            h = formula("x | ~y")
+            truth_table = h.truthtable()
+            truth_table.get_table_list()
+        </input>
+    </sage>
     <idx><h>polynomial</h></idx>
     <sage>
         <input>

--- a/source/boolean-algebra/sec-boolean-functions.ptx
+++ b/source/boolean-algebra/sec-boolean-functions.ptx
@@ -32,6 +32,49 @@
     <p>
         Every Boolean function can be written as a sum-of-products expansion by applying the Boolean identities. Let's find the sum-of-products expansion of the Boolean function <m>h(x, y) = x + \bar{y}</m>.
     </p>
+    <sage>
+        <input>
+            # Applying the identity law
+            # Warning: Do not use 
+            # formula("x &amp; True | True &amp; ~y")
+            # h == formula("x &amp; True | True &amp; ~y")
+            # True and False are not boolean supported with formula
+            # Instead we can assume the &amp; True
+        </input>
+    </sage>
+
+    <sage>
+        <input>
+            # Applying the complement law
+            h_complement = formula("x &amp; (y | ~y) | (x | ~x) &amp;  ~y")
+            h_complement == h
+        </input>
+    </sage>
+    <sage>
+        <input>
+            # Applying the distributive law
+            h_distributive = formula("x &amp; y | x &amp; ~y | x &amp; ~y | ~x &amp; ~y")
+            h_distributive == h
+        </input>
+    </sage>
+    <p>
+        Here is the sum-of-products expansion of the Boolean function <m>h(x, y) = x + \bar{y}</m>. After applying the identity, complement, and distributive laws, we get <m>h(x, y) = x \cdot y + x \cdot \bar{y} + x \cdot \bar{y} + \bar{x} \cdot \bar{y}</m>.
+    </p>
+    <sage>
+        <input>
+            # Applying the idempotent law
+            h_idempotent = formula("x &amp; y | x &amp; ~y | ~x &amp; ~y")
+            h_idempotent == h
+        </input>
+    </sage>
+    <p>
+        We can also confirm the truth table of the <m>h(x, y) = x + \bar{y}</m> and <m>h(x, y) = x \cdot y + x \cdot \bar{y} + x \cdot \bar{y} + \bar{x} \cdot \bar{y}</m> are the same.
+    </p>
+    <sage>
+        <input>
+            h_idempotent.truthtable()
+        </input>
+    </sage>
     
     <idx><h>polynomial</h></idx>
     <sage>

--- a/source/logic/sec-tautology.ptx
+++ b/source/logic/sec-tautology.ptx
@@ -2,66 +2,68 @@
 
 <section xml:id="sec-tautology" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Analyzing Logical Equivalences</title>
-<subsection>
-    <title>Equivalent Statements</title>
-    <p>
-        By comparing the truth tables, we can ascertain if two logical statements are equivalent, meaning they have identical truth values for all possible inputs.
-    </p>
-    <aside>
-        <title>Notes</title>
-        <p>
-            This approach is invaluable in simplifying logical expressions in computer algorithms and understanding proofs in mathematical logic.
-        </p>
-    </aside>
-    <sage>
-        <input>
-            E1 = propcalc.formula('(p -&gt; q) &amp; (q -&gt; r)')
-            E2 = propcalc.formula('p -&gt; r')
-            T1 = E1.truthtable()
-            T2 = E2.truthtable()
-            T1 == T2
-        </input>
-        <output></output>
-    </sage>
-</subsection>
     <subsection>
-    <title>Tautologies</title><idx><h>tautology</h></idx>
-    <p>
-        A tautology is a logical statement that is always true.  The <c>is_tautology()</c> function checks whether a given logical expression is a tautology.
-    </p>
-    <aside>
-        <title>Notes</title>
+        <title>Equivalent Statements</title>
         <p>
-            Understanding tautologies is essential in computer science, particularly in optimizing algorithms and validating logical propositions in software verification. It's also fundamental in mathematical proof strategies, such as proof by contradiction.
+            When working with Sage symbolic logic, the <c>==</c> operator compares semantic equivalence.
         </p>
-    </aside>
-    <sage>
-        <input>
-            a = propcalc.formula('p | ~p')
-            a.is_tautology()
-        </input>
-        <output></output>
-    </sage>
+        <sage>
+            <input>
+                h = propcalc.formula("x | ~y")
+                s = propcalc.formula("x &amp; y | x &amp; ~y | ~x &amp; ~y")
+                h == s
+            </input>
+        </sage>
+        <p>
+            Do not attempt to compare equivalence of truth tables.
+        </p>
+        <sage>
+            <input>
+                # Warning:
+                # Even though these truth tables look identical,
+                # the comparison will return False.
+                h.truthtable() == s.truthtable()
+            </input>
+        </sage>
+        <p>
+            However, we can compare equivalence of truth table <c>lists</c>.
+        </p>
+        <sage>
+            <input>
+                h_list = h.truthtable().get_table_list()
+                s_list = s.truthtable().get_table_list()
+                h_list == s_list
+            </input>
+        </sage>
     </subsection>
-
     <subsection>
-    <title>Contradictions</title><idx><h>contradiction</h></idx>
-    <p>
-        In contrast to tautologies, contradictions are statements that are always false.
-    </p>
-    <aside>
-        <title>Notes</title>
+        <title>Tautologies</title><idx><h>tautology</h></idx>
         <p>
-            Analyzing the relationship between tautologies and contradictions can aid in the development of critical thinking skills, which are essential for debugging in programming, constructing mathematical proofs, and designing logical circuits.
+            A tautology is a logical statement that is always true.  The <c>is_tautology()</c> function checks whether a given logical expression is a tautology.
         </p>
-    </aside>
-    <sage>
-        <input>
-            A = propcalc.formula('p &amp; ~p')
-            A.is_contradiction()  
-        </input>
-        <output></output>
-    </sage>
+        <aside>
+            <title>Notes</title>
+            <p>
+                Understanding tautologies is fundamental in mathematical proof strategies, such as proof by contradiction.
+            </p>
+        </aside>
+        <sage>
+            <input>
+                a = propcalc.formula('p | ~p')
+                a.is_tautology()
+            </input>
+        </sage>
     </subsection>
-
+    <subsection>
+        <title>Contradictions</title><idx><h>contradiction</h></idx>
+        <p>
+            In contrast to tautologies, contradictions are statements that are always false.
+        </p>
+        <sage>
+            <input>
+                A = propcalc.formula('p &amp; ~p')
+                A.is_contradiction()  
+            </input>
+        </sage>
+    </subsection>
 </section>


### PR DESCRIPTION
Originally, I wanted to dive into the simplification of  Boolean functions. After re-watching the Colman lectures I figured there was lots to add to the Boolean Algebra. This PR aims to match the flow of the lecture videos. I didn't want to make a huge PR so I'll dive more into simplification in the next PR.

While working on this chapter, I discovered that we cannot compare truth tables for equivalence. I opened a new issue to address this in the  Logic chapter.

```
# True
h_idempotent == h
```

```
# Why is this False?
h_idempotent.truthtable() == h.truthtable()
```

I have been investigating simplification of Boolean functions in Sage and I am finding the topic very interesting.

This is dated. Not all the links work. Still very informative [Boolean Formulas (Propositional Calculus) in Sage by Andreas Sekine
](https://wstein.org/wiki/attachments/2008(2f)480a(2f)theprojects/sekine.pdf)

If we look at the Sage source code: https://github.com/sagemath/sage/blob/e042294b5ed8e1cb564965079e20e4270ccde340/src/sage/logic/logic.py#L321

```
# TODO: implement the simplify function which calls
# a c++ implementation of the ESPRESSO algorithm
# to simplify the truthtable: probably Minilog
```

Sage simplify() still needs to be implemented. Although c++ ESPRESSO is the way to go, Sympy seems capable. https://stackoverflow.com/questions/68483922/creating-dnf-and-cnf-in-python-out-of-a-logictable-sympy-sagemath 

Strangely, simply() still exists here, but it is commented out from this commit 15 years ago.
https://github.com/sagemath/sage/blob/e042294b5ed8e1cb564965079e20e4270ccde340/src/sage/logic/boolformula.py#L1016

I'm still reviewing https://doc.sagemath.org/html/en/reference/logic/index.html and there is some promise for using currently implemented methods for simplifying Boolean expressions. While covert to Disjunctive Normal Form is not implemented, converting a Boolean formula to conjunctive normal form is implemented. 