### PR TITLE
FrontMatter - Copyright

### DIFF
--- a/source/frontmatter.ptx
+++ b/source/frontmatter.ptx
@@ -190,7 +190,7 @@
     </website>
 
     <copyright>
-      <year>2020<ndash />2024</year>
+      <year>2024<ndash /></year>
       <holder>Zunaid Ahmed, Hellen Colman, Samuel Lubliner</holder>
       <shortlicense> This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
         International License. To view a copy of this license, visit <url


### PR DESCRIPTION
* update start date to 2024 (_first commit in the repo was dated `2/2/24`, unsure on why we would have the copyright start date set to `2020`_)
![image](https://github.com/user-attachments/assets/d9646509-9d06-4e53-9e59-11e231fe21e3)
