### PR TITLE
Added template liscense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,3 +3,30 @@ Creative Commons Attribution - International License (CC BY 4.0)
 Copyright (c) 2024-2025 Zunaid Ahmed, Hellen Colman, Samuel Lubliner
 
 This work is licensed under the Creative Commons Attribution-International License. To view a copy of this license, visit [creativecommons.org/licenses/by/4.0/](https://creativecommons.org/licenses/by/4.0/).
+
+=======================================================================
+This repository is generated from the [pretext-codespace template](https://github.com/PreTeXtBook/pretext-codespace).
+The license for which can be seen below.
+-----------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2025 Oscar Levin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
The MIT license requires that works based off of the licensed software include a copy of the license (see [Key Features](https://tlo.mit.edu/understand-ip/exploring-mit-open-source-license-comprehensive-guide)). 

I added the copy from the pretext codespace template to the license.